### PR TITLE
Improve hover style for links

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -1,6 +1,8 @@
 @import "fonts";
 @import "rouge-github";
 
+@use "sass:color";
+
 body {
   background-color: #fff;
   padding:50px;
@@ -40,8 +42,7 @@ a {
 }
 
 a:hover, a:focus {
-  color:#069;
-  font-weight: bold;
+  color: color.scale(#069, $lightness: 20%);
 }
 
 a small {


### PR DESCRIPTION
I noticed that the current style for links is not completely optimal, as the bold text that appears on hover messes up the formatting a little.

![image](https://user-images.githubusercontent.com/12641361/172449845-a7e4f2c0-2f1b-4ff6-9efc-8d4afc17294c.png)

This PR proposes a fix by replacing the bold text with a slightly lighter (20 %) link color.